### PR TITLE
Fix spelling of default user agent

### DIFF
--- a/modules/rest.c
+++ b/modules/rest.c
@@ -193,7 +193,7 @@ uint32_t ICACHE_FLASH_ATTR REST_Setup(PACKET_CMD *cmd)
 	client->content_type[21] = 0;
 
 	client->user_agent = (uint8_t*)os_zalloc(17);
-	os_sprintf(client->user_agent, "ESPDRUINO@tuanpmt");
+	os_sprintf(client->user_agent, "ESPDUINO@tuanpmt");
 	client->user_agent[16] = 0;
 
 	client->pCon = (struct espconn *)os_zalloc(sizeof(struct espconn));


### PR DESCRIPTION
Default user agent had an "R" in it (espdruino instead of espduino) and it was driving me crazy. I think it also means the array was an incorrect length because of the extra letter, but is now correct with this spelling.
